### PR TITLE
Revert code back to V1.0

### DIFF
--- a/src/Astrocyte.m
+++ b/src/Astrocyte.m
@@ -1,5 +1,10 @@
 classdef Astrocyte < handle
     % test change
+    %% Michelle Edit
+    % Date: 3/2/15 
+    % Changes include: Comment out all the equations and constants that
+    % shouldnt be used.
+    
     properties
         params
         u0
@@ -37,11 +42,12 @@ classdef Astrocyte < handle
             N_Cl_s = N_Na_s + N_K_s - N_HCO3_s;
             
             w_k = u(idx.w_k, :);
-            i_k = u(idx.i_k, :);
-            c_k = u(idx.c_k, :);
-            h_k = u(idx.h_k, :);
-            s_k = u(idx.s_k, :);
-            eet_k = u(idx.eet_k, :);
+            % ----------------------------------------------------------------------
+%             i_k = u(idx.i_k, :);
+%             c_k = u(idx.c_k, :);
+%             h_k = u(idx.h_k, :);
+%             s_k = u(idx.s_k, :);
+%             eet_k = u(idx.eet_k, :);
             du = zeros(size(u));
             
             % Scaling
@@ -100,28 +106,33 @@ classdef Astrocyte < handle
                 (Na_k .* K_k .* Cl_k.^2)) * p.C_correction;
             
             
-            
-            J_IP3 = p.J_max * (...
-                i_k ./ (i_k + p.K_I) .* ...
-                c_k ./ (c_k + p.K_act) .* h_k).^3 .* (1 - c_k ./ s_k);
-            J_ER_leak = p.P_L * (1 - c_k ./ s_k);
-            
-            J_pump = p.V_max * c_k.^2 ./ (c_k.^2 + p.k_pump^2);
+            % --------------------------------------------------------------------
+%             J_IP3 = p.J_max * (...
+%                 i_k ./ (i_k + p.K_I) .* ...
+%                 c_k ./ (c_k + p.K_act) .* h_k).^3 .* (1 - c_k ./ s_k);
+%             J_ER_leak = p.P_L * (1 - c_k ./ s_k);
+%             
+%             J_pump = p.V_max * c_k.^2 ./ (c_k.^2 + p.k_pump^2);
             
             % Other equations
-            B_cyt = 1 ./ (1 + p.BK_end + p.K_ex * p.B_ex ./ ...
-                (p.K_ex + c_k).^2);
-            G = (self.input_rho(t) + p.delta) ./ ...
-                (p.K_G + self.input_rho(t) + p.delta);
+%             B_cyt = 1 ./ (1 + p.BK_end + p.K_ex * p.B_ex ./ ...
+%                 (p.K_ex + c_k).^2);
+%             G = (self.input_rho(t) + p.delta) ./ ...
+%                 (p.K_G + self.input_rho(t) + p.delta);
+%             
+%             v_3 = p.v_5 / 2 * tanh((c_k - p.Ca_3) / p.Ca_4);
             
-            v_3 = p.v_5 / 2 * tanh((c_k - p.Ca_3) / p.Ca_4);
-            
-            
+%             
+%             w_inf = 0.5 * ...
+%                 (1 + tanh((v_k + p.eet_shift * eet_k - v_3) / p.v_4));
+%             
+%             phi_w = p.psi_w * cosh((v_k - v_3) / (2*p.v_4));
+            %% Change to the w inf and phi_w equations
             w_inf = 0.5 * ...
-                (1 + tanh((v_k + p.eet_shift * eet_k - v_3) / p.v_4));
+                (1 + tanh((v_k + p.v_6) / p.v_4));
             
-            phi_w = p.psi_w * cosh((v_k - v_3) / (2*p.v_4));
-            
+            phi_w = p.psi_w * cosh((v_k + p.v_6) / (2*p.v_4));
+            %%
             
             % Right-hand sides
             % Astrocyte
@@ -132,14 +143,14 @@ classdef Astrocyte < handle
             du(idx.N_HCO3_k, :) = 2*J_NBC_k;
             du(idx.N_Cl_k, :) = du(idx.N_Na_k, :) + du(idx.N_K_k, :) - ...
                 du(idx.N_HCO3_k, :);
-            
-            du(idx.c_k, :) = B_cyt .* (J_IP3 - J_pump + J_ER_leak);
-            du(idx.s_k, :) = -1 / p.VR_ER_cyt * du(idx.c_k, :);
-            du(idx.h_k, :) = p.k_on * (p.K_inh - (c_k + p.K_inh) .* h_k);
-            du(idx.i_k, :) = p.r_h * G - p.k_deg * i_k;
-            
-            du(idx.eet_k, :) = p.V_eet * max(c_k - p.c_k_min, 0) - ...
-                p.k_eet * eet_k;
+            % --------------------------------------------------------------------
+%             du(idx.c_k, :) = B_cyt .* (J_IP3 - J_pump + J_ER_leak);
+%             du(idx.s_k, :) = -1 / p.VR_ER_cyt * du(idx.c_k, :);
+%             du(idx.h_k, :) = p.k_on * (p.K_inh - (c_k + p.K_inh) .* h_k);
+%             du(idx.i_k, :) = p.r_h * G - p.k_deg * i_k;
+%             
+%             du(idx.eet_k, :) = p.V_eet * max(c_k - p.c_k_min, 0) - ...
+%                 p.k_eet * eet_k;
             du(idx.w_k, :) = phi_w .* (w_inf - w_k);
             
             du(idx.K_p, :) = J_BK_k ./ (R_k * p.VR_pa) + J_KIR_i ./ ...
@@ -157,15 +168,15 @@ classdef Astrocyte < handle
                Uout(self.idx_out.K_s, :) = K_s;
                Uout(self.idx_out.K_p, :) = K_p;
                Uout(self.idx_out.J_BK_k, :) = J_BK_k;
-               Uout(self.idx_out.rho, :) = self.input_rho(t);
-               Uout(self.idx_out.B_cyt, :) = B_cyt;               
-               Uout(self.idx_out.G, :) = G;               
-               Uout(self.idx_out.v_3, :) = v_3;
+%                Uout(self.idx_out.rho, :) = self.input_rho(t);
+%                Uout(self.idx_out.B_cyt, :) = B_cyt;               
+%                Uout(self.idx_out.G, :) = G;               
+%                Uout(self.idx_out.v_3, :) = v_3;
                Uout(self.idx_out.w_inf, :) = w_inf;
                Uout(self.idx_out.phi_w, :) = phi_w;
-               Uout(self.idx_out.J_IP3, :) = J_IP3;
-               Uout(self.idx_out.J_pump, :) = J_pump;
-               Uout(self.idx_out.J_ER_leak, :) = J_ER_leak;
+%                Uout(self.idx_out.J_IP3, :) = J_IP3;
+%                Uout(self.idx_out.J_pump, :) = J_pump;
+%                Uout(self.idx_out.J_ER_leak, :) = J_ER_leak;
                
                varargout = {Uout};
             end
@@ -214,11 +225,11 @@ idx.N_Na_s = 7;
 idx.N_K_s = 8;
 idx.N_HCO3_s = 9;
 idx.w_k = 10;
-idx.i_k = 11;
-idx.c_k = 12;
-idx.h_k = 13;
-idx.s_k = 14;
-idx.eet_k = 15;
+% idx.i_k = 11;
+% idx.c_k = 12;
+% idx.h_k = 13;
+% idx.s_k = 14;
+% idx.eet_k = 15;
 end
 function [idx, n] = output_indices()
 idx.ft = 1;
@@ -253,23 +264,25 @@ parser.addParameter('F_input', 2.5); %s
 parser.addParameter('alpha', 2);
 parser.addParameter('beta', 5);
 parser.addParameter('delta_t', 10); %s
-parser.addParameter('Amp', 0.7);
-parser.addParameter('base', 0.1);
-parser.addParameter('theta_L', 1);
-parser.addParameter('theta_R', 1);
+% -------------------------------------------------------------------------------
+% parser.addParameter('Amp', 0.7);
+% parser.addParameter('base', 0.1);
+% parser.addParameter('theta_L', 1);
+% parser.addParameter('theta_R', 1);
 
 % Synpatic cleft
 parser.addParameter('k_C', 7.35e-5); %uM m s^-1
 
 % Astrocyte
-parser.addParameter('VR_ER_cyt', 0.185)
-parser.addParameter('k_on', 2); %uM s^-1
-parser.addParameter('K_inh', 0.1); %uM
-parser.addParameter('r_h', 4.8); % uM
-parser.addParameter('k_deg', 1.25); % s^-1
-parser.addParameter('V_eet', 72); % uM
-parser.addParameter('k_eet', 7.2); % uM
-parser.addParameter('c_k_min', 0.1); % uM
+% --------------------------------------------------------------------------------
+% parser.addParameter('VR_ER_cyt', 0.185)
+% parser.addParameter('k_on', 2); %uM s^-1
+% parser.addParameter('K_inh', 0.1); %uM
+% parser.addParameter('r_h', 4.8); % uM
+% parser.addParameter('k_deg', 1.25); % s^-1
+% parser.addParameter('V_eet', 72); % uM
+% parser.addParameter('k_eet', 7.2); % uM
+% parser.addParameter('c_k_min', 0.1); % uM
 
 % Perivascular space
 parser.addParameter('VR_pa', 0.001);
@@ -310,7 +323,10 @@ parser.addParameter('delta', 1.235e-2); %THIS MAY BE WRONG
 parser.addParameter('K_G', 8.82); %uM
 parser.addParameter('v_4', 14.5e-3); %V
 parser.addParameter('v_5', 8e-3); %V
-parser.addParameter('v_6', -15e-3); %V
+%% ----------------------------------------------------------------------------------
+% parser.addParameter('v_6', -15e-3); %V
+parser.addParameter('v_6', 22e-3); %V
+%%
 parser.addParameter('psi_w', 2.664); %s^-1
 parser.addParameter('Ca_3', 0.4);
 parser.addParameter('Ca_4', 0.15);
@@ -341,10 +357,10 @@ u0(idx.N_K_s) = 0.0807e-3;
 u0(idx.N_HCO3_s) = 0.432552e-3;
 u0(idx.K_p) = 3e3;
 u0(idx.w_k) = 0.1815e-3;
-
-u0(idx.c_k) = 0.05e-3;
-u0(idx.s_k) = 0.1e-3;
-u0(idx.h_k) = 0.1e-3;
-u0(idx.i_k) = 0.01e-3;
-u0(idx.eet_k) = 0.1e-3;
+% ----------------------------------------------------------------------------------
+% u0(idx.c_k) = 0.05e-3;
+% u0(idx.s_k) = 0.1e-3;
+% u0(idx.h_k) = 0.1e-3;
+% u0(idx.i_k) = 0.01e-3;
+% u0(idx.eet_k) = 0.1e-3;
 end

--- a/src/SMCEC.m
+++ b/src/SMCEC.m
@@ -104,7 +104,10 @@ classdef SMCEC < handle
                 J_stretch_j - J_Ca_coup_i;
             du(idx.s_j, :) = J_ER_uptake_j - J_CICR_j - J_ER_leak_j;
             du(idx.v_j, :) = -1/p.C_m_j * (J_K_j + J_R_j) - V_coup_i;
+            %% ------------------------------------------------------------------
             du(idx.I_j, :) = p.J_PLC - J_degrad_j - J_IP3_coup_i;
+            %du(idx.I_j, :) = p.J_PLC - J_degrad_j+ J_IP3_coup_i;
+            %%
             du = bsxfun(@times, self.enabled, du);
             
             if nargout == 2
@@ -303,7 +306,7 @@ parser.addParameter('z_5', -7.4e-2); %uM mV^-1 s^-1
 
 parser.addParameter('J_0_j', 0.029); %constant Ca influx (EC)
 
-parser.addParameter('J_PLC', 0.18);
+parser.addParameter('J_PLC', 0.18); % ------------------------------------------------
 
 
 parser.parse(varargin{:})

--- a/src/nvu_script_easy_run.m
+++ b/src/nvu_script_easy_run.m
@@ -1,0 +1,110 @@
+%% Demonstration script for new NVU model reverting back to version 1.0
+%      Author: Michelle Goodman
+%      Date: 3/2/2015
+
+%      For reference 
+%           "Old" refers to version 1.0 orgional prior to Ca and speedfix 
+%           "New" refers to version 1.1 with Ca in astrocyte and speedfix edits
+
+% First copy from old code running types
+close all; clc; clear
+odeopts = odeset('RelTol', 1e-03, 'AbsTol', 1e-03, 'MaxStep', 1); 
+% odeopts = odeset('Vectorized', 1); This was the latest
+
+nv = NVU(Astrocyte(), ...
+    WallMechanics(), ...
+    SMCEC('J_PLC', 0.4), ...
+    'odeopts', odeopts);
+
+
+%% Changing parameters, initial conditions, simulation time to be the same as the old
+nv.smcec.params.J_PLC = 0.4; % new is 0.4;  % (muM s-1) EC agonist concentration  
+%nv.astrocyte.u0(nv.astrocyte.index.K_p) = 3e3;
+nv.T = linspace(0, 500, 1245);
+nv.simulate();
+% Plot, e.g. Ca_i
+figure(1)
+plot(nv.T, nv.out('Ca_i'))
+xlabel('time (s)')
+ylabel('[Ca^{2+}] (\muM)')
+
+figure(2)
+subplot(3, 2, 1)
+plot(nv.T, nv.out('M'))
+xlabel('Time')
+ylabel('Fraction [-]')
+title('[M]')
+
+subplot(3, 2, 2)
+plot(nv.T, nv.out('Mp'))
+xlabel('Time')
+ylabel('Fraction [-]')
+title('[Mp]')
+
+subplot(3, 2, 3)
+plot(nv.T, nv.out('AMp'))
+xlabel('Time')
+ylabel('Fraction [-]')
+title('[AMp]')
+
+subplot(3, 2, 4)
+plot(nv.T, nv.out('AM'))
+xlabel('Time')
+ylabel('Fraction [-]')
+title('[AM]')
+
+subplot(3, 2, 5)
+plot(nv.T, nv.out('F_r'))
+xlabel('Time')
+ylabel('Fraction [-]')
+title('F_r')
+%% IMPORTANT QUANTITY
+subplot(3, 2, 6)
+plot(nv.T, 1e6 * nv.out('R'))
+xlabel('Time')
+ylabel('\mu m')
+title('Radius')
+cd('C:\Users\mlg77\Local Documents\NVU Documentation')
+%desired_save  = [nv.T, 1e6 * nv.out('R'), ];
+desired_save  = [nv.T,1e6 * nv.out('R'), nv.out('Ca_i') , nv.out('J_VOCC_i')', nv.out('v_i'), nv.out('J_KIR_i')', 0.001*nv.out('K_p'), (nv.out('J_BK_k'))'./(nv.out('R_k')), 0.001*nv.out('K_s')' ];
+desired_save(1,10) = nv.smcec.params.J_PLC;
+save('Radius My attempt at old, mu m', 'desired_save')
+cd('C:\Users\mlg77\Local Documents\Git\envy-you-fork\src')
+
+%%
+
+
+%% plot all state variables:
+for i = 1:15
+    figure(3)
+    set(gcf,'name','Astrocyte')
+    subplot(3,5,i)
+    plot(nv.T, nv.out(nv.astrocyte.varnames{i}))
+    h1(i) = gca();
+    ylabel(nv.astrocyte.varnames{i})
+    hold on
+end
+    linkaxes(h1, 'x');
+
+
+for i = 1:10
+    figure(4)
+    set(gcf,'name','ECSMC & WallMechanics')
+    subplot(3,5,i)
+    plot(nv.T, nv.out(nv.smcec.varnames{i}))
+    h2(i) = gca();
+    ylabel(nv.smcec.varnames{i})
+    hold on
+end
+
+    
+for i = 1:4
+    figure(4)
+    subplot(3,5,10+i)
+    plot(nv.T, nv.out(nv.wall.varnames{i}))
+    h2(10+i) = gca();
+    ylabel(nv.wall.varnames{i})
+    hold on
+end
+    linkaxes(h2, 'x');
+    hold on


### PR DESCRIPTION
Changes made to Speedfix code to remove Ca in the astrocyte. Some
parameters, ODE and flux equations removed.
Key Changes include V_6, w_inf, phi_w.
J_IP3 used to check, slight variation at this point
